### PR TITLE
Improved Launching Apps (Non-oops Version)

### DIFF
--- a/app/src/main/java/com/archbrey/letters/DrawerClickListener.java
+++ b/app/src/main/java/com/archbrey/letters/DrawerClickListener.java
@@ -1,10 +1,8 @@
 package com.archbrey.letters;
 
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
@@ -25,15 +23,12 @@ public class DrawerClickListener implements OnItemClickListener  {
     @Override
     public void onItemClick(AdapterView<?> adapterView, View view, int position, long l) {
 
-        Intent launchIntent = pmForListener.getLaunchIntentForPackage(appItemForListener[position].pkgname);
+        Intent launchIntent = pmForListener.getLaunchIntentForPackage(appItemForListener[position].pkgname)
+                .setAction(Intent.ACTION_MAIN);
 
-            //clickListenerContext.startActivity(launchIntent);
-
-        try {
+        if (launchIntent.resolveActivity(pmForListener) != null) {
             clickListenerContext.startActivity(launchIntent);
-        } catch (ActivityNotFoundException e) {
-             Log.d("launch fail","activity not found");
-        } //try*/
+        }
 
     }// public void onItemClick(AdapterView<?> adapterView, View view, int position, long l)
 


### PR DESCRIPTION
This way requires no try/catch block as it is handled by checking if the
package manager can launch an activity with that intent. I've also added
the intent action so that apps that optimize specifically for when they
are opened from the launcher don't break.
